### PR TITLE
Refactor InfoIcon atom

### DIFF
--- a/src/client/ui/atoms/CInfoIcon.ts
+++ b/src/client/ui/atoms/CInfoIcon.ts
@@ -1,0 +1,49 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        CInfoIcon.ts
+ * @module      CInfoIcon
+ * @layer       Client/Atom
+ * @description Simplified info icon atom built on GamePanel.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Trembus
+ * @license      MIT
+ * @since        0.2.0
+ * @lastUpdated  2025-05-29 by Luminesa – Initial creation
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ *
+ * @remarks
+ *   Streamlined version using GamePanel as the root container.
+ */
+
+import Fusion from "@rbxts/fusion";
+import { GamePanel, GameImage, GameText } from "../core";
+import { Pad } from "../quarks";
+
+export interface CInfoIconProps {
+    Image: string;
+    Value: Fusion.Value<string | number>;
+}
+
+export const CInfoIcon = (props: CInfoIconProps) =>
+    GamePanel({
+        Name: "CInfoIcon",
+        Size: UDim2.fromOffset(70, 70),
+        Padding: Pad.Bottom(new UDim(0.02, 0)),
+        Children: {
+            Icon: GameImage({ Image: props.Image, Size: UDim2.fromScale(1, 1) }),
+            Label: GameText({
+                ValueText: props.Value,
+                AnchorPoint: new Vector2(0.5, 1),
+                Position: UDim2.fromScale(0.5, 1),
+                Size: UDim2.fromScale(0.9, 0.2),
+            }),
+        },
+    });

--- a/src/client/ui/atoms/InfoIcon.ts
+++ b/src/client/ui/atoms/InfoIcon.ts
@@ -1,57 +1,59 @@
-import Fusion, { New, Children, Computed } from "@rbxts/fusion";
+/*
+ * This component was replaced by `CInfoIcon` which leverages the
+ * `GamePanel` atom for consistency. The original implementation is kept
+ * here for reference but is no longer compiled.
+ */
+
+/*
+import Fusion, { New, Children } from "@rbxts/fusion";
 import { GameText } from "./text";
 
 export interface InfoIcon {
-	assetId: string;
-	fusionValue: Fusion.Value<string | number>;
+        assetId: string;
+        fusionValue: Fusion.Value<string | number>;
 }
 
 export const InfoIcon = (props: InfoIcon) => {
-	const component = New("ImageLabel")({
-		Name: "ValueImage",
-		AnchorPoint: new Vector2(0.5, 0.5),
-		BackgroundTransparency: 1,
-		Image: props.assetId,
-		Position: UDim2.fromScale(0.5, 0.5),
-		Size: UDim2.fromOffset(70, 70),
-
-		[Children]: [
-			New("Frame")({
-				Name: "Frame",
-				AnchorPoint: new Vector2(0.5, 1),
-				BackgroundColor3: new Color3(),
-				BackgroundTransparency: 0.3,
-				Position: UDim2.fromScale(0.5, 1),
-				Size: UDim2.fromScale(0.9, 0.2),
-
-				[Children]: [
-					GameText({
-						ValueText: props.fusionValue,
-						AnchorPoint: new Vector2(0.5, 0.5),
-						Position: UDim2.fromScale(0.5, 0.5),
-					}),
-				],
-			}),
-
-			New("UIPadding")({
-				Name: "UIPadding",
-				PaddingBottom: new UDim(0.02, 0),
-			}),
-
-			New("UICorner")({
-				Name: "UICorner",
-			}),
-
-			New("UIStroke")({
-				Name: "UIStroke",
-				LineJoinMode: Enum.LineJoinMode.Bevel,
-				Thickness: 4,
-			}),
-
-			New("UIAspectRatioConstraint")({
-				Name: "UIAspectRatioConstraint",
-			}),
-		],
-	});
-	return component;
+        const component = New("ImageLabel")({
+                Name: "ValueImage",
+                AnchorPoint: new Vector2(0.5, 0.5),
+                BackgroundTransparency: 1,
+                Image: props.assetId,
+                Position: UDim2.fromScale(0.5, 0.5),
+                Size: UDim2.fromOffset(70, 70),
+                [Children]: [
+                        New("Frame")({
+                                Name: "Frame",
+                                AnchorPoint: new Vector2(0.5, 1),
+                                BackgroundColor3: new Color3(),
+                                BackgroundTransparency: 0.3,
+                                Position: UDim2.fromScale(0.5, 1),
+                                Size: UDim2.fromScale(0.9, 0.2),
+                                [Children]: [
+                                        GameText({
+                                                ValueText: props.fusionValue,
+                                                AnchorPoint: new Vector2(0.5, 0.5),
+                                                Position: UDim2.fromScale(0.5, 0.5),
+                                        }),
+                                ],
+                        }),
+                        New("UIPadding")({
+                                Name: "UIPadding",
+                                PaddingBottom: new UDim(0.02, 0),
+                        }),
+                        New("UICorner")({
+                                Name: "UICorner",
+                        }),
+                        New("UIStroke")({
+                                Name: "UIStroke",
+                                LineJoinMode: Enum.LineJoinMode.Bevel,
+                                Thickness: 4,
+                        }),
+                        New("UIAspectRatioConstraint")({
+                                Name: "UIAspectRatioConstraint",
+                        }),
+                ],
+        });
+        return component;
 };
+*/

--- a/src/client/ui/atoms/index.ts
+++ b/src/client/ui/atoms/index.ts
@@ -4,4 +4,4 @@ export * from "./image";
 export * from "./text";
 export * from "./Avatar";
 export * from "../core/GameText";
-export * from "./InfoIcon";
+export * from "./CInfoIcon";


### PR DESCRIPTION
## Summary
- comment out original InfoIcon implementation
- add new GamePanel-based `CInfoIcon` atom
- export new atom from barrel

## Testing
- `npm run lint`
- `npm test` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfa98a8848327961842fc279be590