### PR TITLE
Refactor GameText and add label variants

### DIFF
--- a/src/client/ui/core/CoreInterfaces.ts
+++ b/src/client/ui/core/CoreInterfaces.ts
@@ -19,8 +19,19 @@ export interface GamePanelProps extends PropertyTable<Frame> {
 
 /* =============================================== GameText Props ========================================= */
 export interface GameTextProps extends PropertyTable<TextLabel> {
-	ValueText?: Fusion.Value<string | number>;
+        ValueText?: Fusion.Value<string | number>;
+        HoverText?: string | Fusion.Value<string>;
+        Variant?: "flat" | "recessed" | "extruded";
 }
+
+export interface InfoLabelProps extends GamePanelProps {
+        Label: string | Fusion.Value<string>;
+        Value: Fusion.Value<string | number>;
+        HoverText?: string | Fusion.Value<string>;
+        Variant?: "flat" | "recessed" | "extruded";
+}
+
+export interface CounterLabelProps extends InfoLabelProps {}
 
 /* =============================================== GameImage Props ========================================= */
 export interface GameImageProps extends PropertyTable<ImageLabel> {

--- a/src/client/ui/core/GameText.ts
+++ b/src/client/ui/core/GameText.ts
@@ -4,7 +4,7 @@
  * @file        GameText.ts
  * @module      GameText
  * @layer       Client/Atom
- * @description Simple text label wrapper with default styling.
+ * @description Styled text label atom with optional hover text.
  *
  * ╭───────────────────────────────╮
  * │  Soul Steel · Coding Guide    │
@@ -14,31 +14,97 @@
  * @author       Trembus
  * @license      MIT
  * @since        0.2.0
- * @lastUpdated  2025-05-29 by Luminesa – Initial creation
+ * @lastUpdated  2025-06-15 by Trembus – Added label variants and hover text
  *
  * @dependencies
  *   @rbxts/fusion ^0.4.0
  */
 
-import Fusion, { New, Computed, Value } from "@rbxts/fusion";
-import { GameColors } from "../quarks";
-import { GameTextProps } from "./CoreInterfaces";
+import Fusion, { New, Children, Computed, Value, OnEvent } from "@rbxts/fusion";
+import { GameColors, Layout, ShadowGradient } from "../quarks";
+import { GamePanel } from "./GamePanel";
+import { BorderImage } from "./GameImage";
+import { GameTextProps, InfoLabelProps, CounterLabelProps } from "./CoreInterfaces";
 
 export const GameText = (props: GameTextProps) => {
-	const textState = typeIs(props.ValueText, "table")
-		? (props.ValueText as Fusion.Value<string | number>)
-		: Value(props.ValueText);
+        const textState = typeIs(props.ValueText, "table")
+                ? (props.ValueText as Fusion.Value<string | number>)
+                : Value(props.ValueText ?? "");
 
-	return New("TextLabel")({
-		Name: props.Name ?? "GameText",
-		AnchorPoint: props.AnchorPoint ?? new Vector2(0.5, 0.5),
-		BackgroundTransparency: 1,
-		FontFace: new Font("rbxasset://fonts/families/Inconsolata.json"),
-		Position: props.Position ?? UDim2.fromScale(0.5, 0.5),
-		Size: props.Size ?? UDim2.fromScale(1, 1),
-		TextSize: props.TextSize ?? 24,
-		Text: Computed(() => tostring(textState.get())),
-		TextColor3: props.TextColor3 ?? GameColors.TextDefault,
-		TextScaled: false,
-	});
+        const hoverState = Value(false);
+        const hoverLabel = props.HoverText
+                ? New("TextLabel")({
+                              Name: "HoverText",
+                              AnchorPoint: new Vector2(0.5, 1),
+                              BackgroundColor3: GameColors.BackgroundDefault,
+                              BackgroundTransparency: 0.2,
+                              Position: UDim2.fromScale(0.5, 0),
+                              Size: UDim2.fromOffset(80, 20),
+                              Visible: hoverState,
+                              FontFace: new Font("rbxasset://fonts/families/Inconsolata.json"),
+                              Text: typeIs(props.HoverText, "table")
+                                      ? Computed(() => (props.HoverText as Fusion.Value<string>).get())
+                                      : tostring(props.HoverText),
+                              TextColor3: GameColors.TextDefault,
+                              TextSize: typeIs(props.TextSize, "number") ? (props.TextSize as number) * 0.8 : 16,
+                      })
+                : undefined;
+
+        return New("TextLabel")({
+                Name: props.Name ?? "GameText",
+                AnchorPoint: props.AnchorPoint ?? new Vector2(0.5, 0.5),
+                BackgroundTransparency: props.Variant ? 0.2 : 1,
+                BackgroundColor3:
+                        props.Variant === "recessed"
+                                ? GameColors.BackgroundHover
+                                : GameColors.BackgroundDefault,
+                FontFace: new Font("rbxasset://fonts/families/Inconsolata.json"),
+                Position: props.Position ?? UDim2.fromScale(0.5, 0.5),
+                Size: props.Size ?? UDim2.fromScale(1, 1),
+                TextSize: props.TextSize ?? 24,
+                Text: Computed(() => tostring(textState.get())),
+                TextColor3: props.TextColor3 ?? GameColors.TextDefault,
+                TextScaled: false,
+                [OnEvent("MouseEnter")]: props.HoverText ? () => hoverState.set(true) : undefined,
+                [OnEvent("MouseLeave")]: props.HoverText ? () => hoverState.set(false) : undefined,
+                [Children]: {
+                        Hover: hoverLabel,
+                        Corner: props.Variant ? New("UICorner")({}) : undefined,
+                        Shadow: props.Variant === "recessed" ? ShadowGradient() : undefined,
+                },
+        });
 };
+
+export const InfoLabel = (props: InfoLabelProps) => {
+        const label = typeIs(props.Label, "table")
+                ? (props.Label as Fusion.Value<string>)
+                : Value(props.Label);
+        const value = props.Value;
+
+        return GamePanel({
+                Name: props.Name ?? "InfoLabel",
+                Size: props.Size ?? UDim2.fromOffset(140, 24),
+                Layout: Layout.HorizontalList(4),
+                BorderImage: props.Variant === "extruded" ? BorderImage.GothicMetal() : undefined,
+                Gradient: props.Variant === "recessed" ? ShadowGradient() : undefined,
+                HoverEffect: props.HoverText !== undefined,
+                Children: {
+                        Label: GameText({
+                                ValueText: label,
+                                AnchorPoint: new Vector2(0, 0.5),
+                                Position: UDim2.fromScale(0, 0.5),
+                                TextXAlignment: Enum.TextXAlignment.Left,
+                        }),
+                        Value: GameText({
+                                ValueText: value,
+                                AnchorPoint: new Vector2(1, 0.5),
+                                Position: UDim2.fromScale(1, 0.5),
+                                TextXAlignment: Enum.TextXAlignment.Right,
+                                HoverText: props.HoverText,
+                                Variant: props.Variant,
+                        }),
+                },
+        });
+};
+
+export const CounterLabel = (props: CounterLabelProps) => InfoLabel(props);

--- a/src/client/ui/core/index.ts
+++ b/src/client/ui/core/index.ts
@@ -24,5 +24,6 @@ export * from "./CoreInterfaces";
 export * from "./GameButton"; // Clickable button atom built on `ImageButton`.
 export * from "./GameImage"; // Lightweight wrapper around `ImageLabel`.
 export * from "./GamePanel"; // Foundational Atom that serves as the base of any custom component that would use a Frame object.
-export * from "./GameText"; // Simple text label wrapper with default styling.
+export * from "./GameText"; // Styled text label atom.
+export { InfoLabel, CounterLabel } from "./GameText";
 //export * from "./GameMeter"; // A simple progress bar component.

--- a/src/client/ui/molecules/AttributeControl.ts
+++ b/src/client/ui/molecules/AttributeControl.ts
@@ -1,6 +1,28 @@
-/* ==================================== Attribute Control Imports ==================================== */
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        AttributeControl.ts
+ * @module      AttributeControl
+ * @layer       Client/Molecule
+ * @description UI element for modifying player attributes.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Trembus
+ * @license      MIT
+ * @since        0.2.0
+ * @lastUpdated  2025-06-15 by Trembus – Added header
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
+/* ==================================== Attribute Control Imports ====================== */
 import Fusion, { Value } from "@rbxts/fusion";
-import { GameText, GamePanel, GameImage, GameButton } from "../core";
+import { GameText, GamePanel, GameImage, GameButton, InfoLabel } from "../core";
 import { Layout, Pad } from "../quarks";
 import { AttributeKey, AttributesMeta } from "shared";
 import { PlayerState } from "../states";
@@ -29,17 +51,12 @@ export const AttributeControl = (props: AttributeControlProps) => {
 		Image: iconId,
 	});
 
-	// Attribute Name
-	const attributeName = GameText({
-		ValueText: Value(displayName),
-		TextSize: 14,
-		TextColor3: Color3.fromRGB(255, 255, 255),
-	});
-
-	// Attribute Value
-	const attributeValue = GameText({
-		ValueText: attributeState,
-	});
+        // Attribute Label and Value
+        const attributeLabel = InfoLabel({
+                Label: Value(displayName),
+                Value: attributeState,
+                Variant: "recessed",
+        });
 
 	// Increment Button
 	const incrementButton = GameButton({
@@ -66,13 +83,12 @@ export const AttributeControl = (props: AttributeControlProps) => {
 		BorderSizePixel: 0,
 		Layout: Layout.HorizontalSet(),
 		Padding: Pad.All(new UDim(0, 3)),
-		Children: {
-			Icon: attributeIcon,
-			DisplayName: attributeName,
-			Value: attributeValue,
-			IncrementButton: incrementButton,
-			DecrementButton: decrementButton,
-		},
+                Children: {
+                        Icon: attributeIcon,
+                        Label: attributeLabel,
+                        IncrementButton: incrementButton,
+                        DecrementButton: decrementButton,
+                },
 	});
 
 	// Retrun Custom Component

--- a/src/client/ui/molecules/Meter.ts
+++ b/src/client/ui/molecules/Meter.ts
@@ -1,3 +1,25 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        Meter.ts
+ * @module      Meter
+ * @layer       Client/Molecule
+ * @description Progress meter with label and optional frame image.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ *
+ * @author       Trembus
+ * @license      MIT
+ * @since        0.2.0
+ * @lastUpdated  2025-06-15 by Trembus – Added header
+ *
+ * @dependencies
+ *   @rbxts/fusion ^0.4.0
+ */
+
 import Fusion, { Computed, Value } from "@rbxts/fusion";
 import { MeterState } from "../states/MeterState";
 import { GameImage, GameText, GamePanel } from "../core";


### PR DESCRIPTION
## Summary
- extend `GameText` with hover text and visual variants
- add new `InfoLabel` and `CounterLabel` helpers
- update barrel exports
- refactor `AttributeControl` to use `InfoLabel`
- add missing headers to molecule components

## Testing
- `npm test` *(fails: `rojo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfe54aa8c83279655084eb731de57