### PR TITLE
Add test helper script and new gradient quarks

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Simple helper script to run the project's tests.
+# It checks for required CLI tools and tries to install
+# them using npm if they are missing.
+set -e
+
+require() {
+    if ! command -v "$1" >/dev/null; then
+        return 1
+    fi
+}
+
+# Ensure Node.js is available
+if ! command -v npm >/dev/null; then
+    echo "Error: npm is not installed. Install Node.js to continue." >&2
+    exit 1
+fi
+
+# Install dependencies if node_modules does not exist
+if [ ! -d node_modules ]; then
+    echo "Installing npm dependencies..."
+    npm install
+fi
+
+# Check for roblox related tools
+missing=0
+if ! require rbxtsc; then
+    echo "rbxtsc not found. Installing roblox-ts globally..."
+    npm install -g roblox-ts || missing=1
+fi
+if ! require rojo; then
+    echo "Rojo CLI not found. Installing rojo-cli globally..."
+    npm install -g rojo-cli || missing=1
+fi
+if ! require lemur; then
+    echo "Lemur CLI not found. Installing lemur globally..."
+    npm install -g lemur || missing=1
+fi
+
+if [ "$missing" -eq 1 ]; then
+    echo "One or more tools failed to install. Please check the output above." >&2
+fi
+
+# Run the actual test command
+npm test

--- a/src/client/ui/quarks/gradients.ts
+++ b/src/client/ui/quarks/gradients.ts
@@ -30,3 +30,49 @@ export const OldShadowGradient = () =>
 			new NumberSequenceKeypoint(1, 0.625, 0.1875),
 		]),
 	});
+
+/**
+ * Warm sunrise style gradient.
+ */
+export const SunriseGradient = () =>
+        New("UIGradient")({
+                Name: "SunriseGradient",
+                Color: new ColorSequence([
+                        new ColorSequenceKeypoint(0, Color3.fromRGB(255, 170, 0)),
+                        new ColorSequenceKeypoint(0.5, Color3.fromRGB(255, 85, 0)),
+                        new ColorSequenceKeypoint(1, Color3.fromRGB(128, 0, 128)),
+                ]),
+                Transparency: new NumberSequence(0),
+                Rotation: 90,
+        });
+
+/**
+ * Simple blue gradient useful for backgrounds.
+ */
+export const OceanGradient = () =>
+        New("UIGradient")({
+                Name: "OceanGradient",
+                Color: new ColorSequence([
+                        new ColorSequenceKeypoint(0, Color3.fromRGB(0, 170, 255)),
+                        new ColorSequenceKeypoint(1, Color3.fromRGB(0, 85, 170)),
+                ]),
+                Transparency: new NumberSequence(0),
+        });
+
+/**
+ * Glass-like glow with transparent center.
+ */
+export const GlassGradient = () =>
+        New("UIGradient")({
+                Name: "GlassGradient",
+                Color: new ColorSequence([
+                        new ColorSequenceKeypoint(0, new Color3(1, 1, 1)),
+                        new ColorSequenceKeypoint(0.5, new Color3(1, 1, 1)),
+                        new ColorSequenceKeypoint(1, new Color3(1, 1, 1)),
+                ]),
+                Transparency: new NumberSequence([
+                        new NumberSequenceKeypoint(0, 0.8),
+                        new NumberSequenceKeypoint(0.5, 0.3),
+                        new NumberSequenceKeypoint(1, 0.8),
+                ]),
+        });


### PR DESCRIPTION
## Summary
- add `run-tests.sh` script to help install tools and execute the test pipeline
- expand `gradients.ts` with Sunrise, Ocean, and Glass gradients

## Testing
- `npm run lint` *(fails: 225 problems, 1 error)*
- `npm test` *(fails: `rojo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684e02222b1c8327a5291c6c4f8bb3ec